### PR TITLE
IDEAS-42: Remove the word 'home' from homepage title

### DIFF
--- a/src/main/resources/Ideas/IdeasHomeSheet.xml
+++ b/src/main/resources/Ideas/IdeasHomeSheet.xml
@@ -14,7 +14,7 @@
   <date>1413981968000</date>
   <contentUpdateDate>1413980738000</contentUpdateDate>
   <version>1.1</version>
-  <title>$msg.get('platform.appwithinminutes.appHomePageTitle', $doc.space)</title>
+  <title>$services.localization.render('ideas.home.title')</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>

--- a/src/main/resources/Ideas/IdeasTranslations.fr.xml
+++ b/src/main/resources/Ideas/IdeasTranslations.fr.xml
@@ -19,7 +19,11 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content># Class fields
+  <content>#Titles
+ideas.app.title=Idées
+ideas.home.title=Idées
+
+# Class fields
 Ideas.IdeasClass_title1=Idée
 Ideas.IdeasClass_content1=Description
 Ideas.IdeasClass_nbvotes=Votes

--- a/src/main/resources/Ideas/IdeasTranslations.xml
+++ b/src/main/resources/Ideas/IdeasTranslations.xml
@@ -19,7 +19,11 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content># Class fields
+  <content>#Titles
+ideas.app.title=Ideas
+ideas.home.title=Ideas
+
+# Class fields
 Ideas.IdeasClass_title1=Idea
 Ideas.IdeasClass_content1=Description
 Ideas.IdeasClass_nbvotes=Votes

--- a/src/main/resources/Ideas/WebHome.xml
+++ b/src/main/resources/Ideas/WebHome.xml
@@ -258,7 +258,7 @@ $msg.get('ideas.home.description')
       <name>platform.panels.IdeasApplication</name>
     </property>
     <property>
-      <parameters>label=Ideas
+      <parameters>label=$services.localization.render('ideas.app.title')
 target=Ideas.WebHome
 icon=icon:lightbulb</parameters>
     </property>


### PR DESCRIPTION
* Also fixes IDEAS-44: Create french translation for the entry in app panel and the title from homepage